### PR TITLE
[Vagrant] Fix ember aliases

### DIFF
--- a/scripts/aliases
+++ b/scripts/aliases
@@ -33,8 +33,8 @@ alias ccf='./vendor/bin/codecept Functional'
 alias ccu='./vendor/bin/codecept run Unit'
 
 #ember/js stuff
-alias ember='/vagrant/workbench/flarum/core/ember/node_modules/ember-cli/bin/ember'
-alias esv='cd /vagrant/workbench/flarum/core/ember && /vagrant/workbench/flarum/core/ember/node_modules/ember-cli/bin/ember serve --output-path="../public"'
+alias ember='/vagrant/flarum/core/ember/node_modules/ember-cli/bin/ember'
+alias esv='cd /vagrant/flarum/core/ember && /vagrant/flarum/core/ember/node_modules/ember-cli/bin/ember serve --output-path="../public"'
 
 #function aliases
 alias ghc=ghc


### PR DESCRIPTION
These were apparently still pointing to the old L4 structure.