### PR TITLE
Fixed Node JS install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -282,7 +282,7 @@ Vagrant.configure("2") do |config|
   ##########
 
   # Install Nodejs
-  config.vm.provision "shell", path: "https://raw.githubusercontent.com/franzliedke/Vaprobash/patch-1/scripts/nodejs.sh", privileged: false, args: nodejs_packages.unshift(nodejs_version, github_url)
+  config.vm.provision "shell", path: "https://raw.githubusercontent.com/fideloper/Vaprobash/master/scripts/nodejs.sh", privileged: false, args: nodejs_packages.unshift(nodejs_version, github_url)
 
   # Install Ruby Version Manager (RVM)
   # config.vm.provision "shell", path: "#{github_url}/scripts/rvm.sh", privileged: false, args: ruby_gems.unshift(ruby_version)


### PR DESCRIPTION
Restored original Vaprobash's script for Node JS install works fine.

The current script run this: https://github.com/franzliedke/Vaprobash/blob/patch-1/scripts/nodejs.sh#L48 but the response of "https://nodejs.org" request is:

```
<html>
<head><title>302 Found</title></head>
<body bgcolor="white">
<center><h1>302 Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
```