### PR TITLE
Use pipe instead of redirect for release.zip

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,11 +6,9 @@ release=/tmp/flarum-release
 rm -rf ${release}
 mkdir ${release}
 
-git archive --format zip --worktree-attributes HEAD > ${release}/release.zip
+git archive --format tar --worktree-attributes HEAD | tar -xC ${release}
 
 cd ${release}
-unzip release.zip -d ./
-rm release.zip
 
 # Delete files
 rm -rf ${release}/build.sh


### PR DESCRIPTION
Directly pipes from git archive to extract to ${release} instead of creating release.zip, changing to the ${release} directory, unzipping release.zip, then removing release.zip.