### PR TITLE
Added Incremental Compile 

### DIFF
--- a/fullbuild.sh
+++ b/fullbuild.sh
@@ -218,6 +218,12 @@
     ## | Incremental Compile Extensions
     }
 
+    setvariables() {
+        # Set flarum_source if not already set - default to script location
+        if [ -v $flarum_source ]; then flarum_source=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd); fi
+        # Set compiled_flarum location if not already set - default to random /tmp/tmp.* location
+        if [ -v $compiled_flarum ]; then compiled_flarum=$(mktemp -d); removetmp=yes; fi
+        if [ -v $export ]; then export=/tmp/; fi
 
     removeextras() {
         ### Remove Extra Files
@@ -283,6 +289,7 @@
                 exit
                 ;;
             i)
+                setvariables
                 update_repos
                 incrementalupdate
                 removeextras
@@ -307,14 +314,6 @@
                 ;;
         esac
     done
-
-
-    # Set flarum_source if not already set - default to script location
-    if [ -v $flarum_source ]; then flarum_source=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd); fi
-    # Set compiled_flarum location if not already set - default to random /tmp/tmp.* location
-    if [ -v $compiled_flarum ]; then compiled_flarum=$(mktemp -d); removetmp=yes; fi
-    if [ -v $export ]; then export=/tmp/; fi
-
 
     update_repos
     copytorelease

--- a/fullbuild.sh
+++ b/fullbuild.sh
@@ -316,6 +316,7 @@
         esac
     done
 
+    setvariables
     update_repos
     copytorelease
     compilereleaseflarum

--- a/fullbuild.sh
+++ b/fullbuild.sh
@@ -139,7 +139,7 @@
             echo -e '\nWarning! Incremental update Not heavily tested!\n'
             cd $compiled_flarum
             orginal_sum="$(grep "flarum/core" $flarum_source/INCR_COMPILE | awk '{ print $3 }')"
-            new_sum="$(cd $flarum_source/core; git log -1 | head -n1 | cut -d\  -f2 | cut -b1-10)"
+            new_sum="$(cd $flarum_source/flarum/core; git log -1 | head -n1 | cut -d\  -f2 | cut -b1-10)"
             
             if [ "$orginal_sum" != "$new_sum" ]
               then

--- a/fullbuild.sh
+++ b/fullbuild.sh
@@ -20,9 +20,9 @@
             cd $flarum_source
             echo latest commit $(git log -1 | head -n1 | cut -d\  -f2 | cut -b1-10) - flarum
             # Ensure Core is up to date - https://github.com/flarum/core
-	    if [ -d core ]; then ( cd core; echo latest commit $(git log -1 | head -n1 | cut -d\  -f2 | cut -b1-10) - flarum/core) > $flarum_source/INCR_COMPILE; fi
-            echo latest commit $(git log -1 | head -n1 | cut -d\  -f2 | cut -b1-10) - flarum/core
-            git clone https://github.com/flarum/core 2> /dev/null || (cd flarum/core/ && git pull)
+            if [ -d flarum/core ]; then ( cd flarum/core; echo latest commit $(git log -1 | head -n1 | cut -d\  -f2 | cut -b1-10) - flarum/core) > $flarum_source/INCR_COMPILE; fi
+            ( cd flarum/core; echo latest commit $(git log -1 | head -n1 | cut -d\  -f2 | cut -b1-10) - flarum/core)
+            git clone https://github.com/flarum/core flarum/core 2> /dev/null || (cd flarum/core/ && git pull)
 
             # Ensure Extensions are up to date
             for extension in $default_extensions;
@@ -30,7 +30,7 @@
             (
                 cd extensions/
                 mkdir -p $extension
-		if [ -d $extension ]; then ( cd $extension; echo latest commit $(git log -1 | head -n1 | cut -d\  -f2 | cut -b1-10) - flarum/$extension) >> $flarum_source/INCR_COMPILE; fi
+                if [ -d $extension ]; then ( cd $extension; echo latest commit $(git log -1 | head -n1 | cut -d\  -f2 | cut -b1-10) - flarum/$extension) >> $flarum_source/INCR_COMPILE; fi
                 git clone https://github.com/flarum/"$extension" || (cd $extension; git pull)
                 (cd $extension; echo latest commit $(git log -1 | head -n1 | cut -d\  -f2 | cut -b1-10) - flarum/$extension)
             )

--- a/fullbuild.sh
+++ b/fullbuild.sh
@@ -224,6 +224,7 @@
         # Set compiled_flarum location if not already set - default to random /tmp/tmp.* location
         if [ -v $compiled_flarum ]; then compiled_flarum=$(mktemp -d); removetmp=yes; fi
         if [ -v $export ]; then export=/tmp/; fi
+    }
 
     removeextras() {
         ### Remove Extra Files


### PR DESCRIPTION
This makes compiling much faster when used since it ignores compiling stuff when the relevant part (core, extension)'s hash hasn't changed.

___


**must** be run after a prior initial normal run with -d set
eg
./fullbuild.sh -d ~/compile_location 
then
./fullbuild.sh -d ~/compile_location -i