### PR TITLE
Do not attempt to create database when it exists

### DIFF
--- a/flarum/vagrant/environment.sh
+++ b/flarum/vagrant/environment.sh
@@ -69,7 +69,7 @@ else
     echo "source ~/.aliases" >> ~/.bashrc
 fi
 
-mysql -u root -proot -e 'create database flarum'
+mysql -u root -proot -e 'create database if not exists flarum'
 
 ### Setup flarum/core and install dependencies ###
 cd /vagrant/flarum/core


### PR DESCRIPTION
When trying to re-provision the Vagrant box, the current script throws the error:

> ==> Vaprobash: : Can't create database 'flarum'; database exists

This can easily be avoided by using the query provided.