### PR TITLE
Adding support for apache 2.4

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,11 +1,22 @@
 # Allow access if Flarum is installed in a subdirectory,
 # but another .htaccess in a higher directory denies access.
-Order Allow,Deny
-Allow from all
 
-<Files flarum/*>
-  Deny from All
-</Files>
+<IfModule mod_authz_host.c>
+  Require all granted
+
+  <Files flarum/*>
+    Require all denied	  
+  </Files>
+</IfModule>
+<IfModule !mod_authz_host.c>
+  Order Allow,Deny
+  Allow from all
+
+  <Files flarum/*>
+    Deny from All
+  </Files>
+</IfModule>
+
 
 <IfModule mod_rewrite.c>
   RewriteEngine on


### PR DESCRIPTION
Using mod_access_compat is depricated and may cause problems on some systems. It's replaced with mod_authz_host

http://httpd.apache.org/docs/2.4/mod/mod_access_compat.html
"The directives provided by mod_access_compat have been deprecated by the new authz refactoring. Please see mod_authz_host."