### PR TITLE
Ignore .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 .DS_Store
 Thumbs.db
 .vagrant


### PR DESCRIPTION
I use Visual Studio Code (as many others these days) and I wanted to have the .vscode folder ignored from GIT, if possible