### PR TITLE
Extract duplicated site setup to shared file

### DIFF
--- a/flarum
+++ b/flarum
@@ -8,14 +8,17 @@
  * LICENSE file that was distributed with this source code.
  */
 
-require 'vendor/autoload.php';
+$site = require 'site.php';
 
-$server = new Flarum\Console\Server(
-    Flarum\Foundation\Site::fromPaths([
-        'base' => __DIR__,
-        'public' => __DIR__.'/public',
-        'storage' => __DIR__.'/storage',
-    ])
-);
+/*
+|-------------------------------------------------------------------------------
+| Interpret console arguments
+|-------------------------------------------------------------------------------
+|
+| Flarum's console interprets all command-line arguments to select and then
+| execute corresponding commands for certain administrative tasks.
+|
+*/
 
+$server = new Flarum\Console\Server($site);
 $server->listen();

--- a/public/index.php
+++ b/public/index.php
@@ -7,14 +7,20 @@
  * LICENSE file that was distributed with this source code.
  */
 
-require '../vendor/autoload.php';
+$site = require '../site.php';
 
-$server = new Flarum\Http\Server(
-    Flarum\Foundation\Site::fromPaths([
-        'base' => __DIR__.'/..',
-        'public' => __DIR__.'/../public',
-        'storage' => __DIR__.'/../storage',
-    ])
-);
+/*
+|-------------------------------------------------------------------------------
+| Accept incoming HTTP requests
+|-------------------------------------------------------------------------------
+|
+| Every HTTP request pointed to the web server that cannot be served by simply
+| responding with one of the files in the "public" directory will be sent to
+| this file. Now is the time to boot up Flarum's internal HTTP server, which
+| will try its best to interpret the request and return the appropriate
+| response, which could be a JSON document (for API responses) or a lot of HTML.
+|
+*/
 
+$server = new Flarum\Http\Server($site);
 $server->listen();

--- a/site.php
+++ b/site.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+/*
+|-------------------------------------------------------------------------------
+| Load the autoloader
+|-------------------------------------------------------------------------------
+|
+| First, let's include the autoloader, which is generated automatically by
+| Composer (PHP's package manager) after installing our dependencies.
+| From now on, all classes in our dependencies will be usable without
+| explicitly loading any files.
+|
+*/
+
+require __DIR__.'/vendor/autoload.php';
+
+/*
+|-------------------------------------------------------------------------------
+| Configure the site
+|-------------------------------------------------------------------------------
+|
+| A Flarum site represents your local installation of Flarum. It can be
+| configured with a bunch of paths:
+|
+| - The *base path* is Flarum's root directory and contains important files
+|   such as config.php and extend.php.
+| - The *public path* is the directory that serves as document root for the
+|   web server. Files in this place are accessible to the public internet.
+|   This is where assets such as JavaScript files or CSS stylesheets need to
+|   be stored in a default install.
+| - The *storage path* is a place for Flarum to store files it generates during
+|   runtime. This could be caches, session data or other temporary files.
+|
+| The fully configured site instance is returned to the including script, which
+| then uses it to boot up the Flarum application and e.g. accept web requests.
+|
+*/
+
+return Flarum\Foundation\Site::fromPaths([
+    'base' => __DIR__,
+    'public' => __DIR__.'/public',
+    'storage' => __DIR__.'/storage',
+]);


### PR DESCRIPTION
This extracts a common `site.php` file that sets up paths, as discussed in flarum/core#1669.

What this does *not* do (yet?):
- Introduce a `bootstrap` directory to hold `site.php` and `extend.php`, as that would require further changes to existing app's skeleton, and I don't see the value in it to justify the effort.
- Introduce any auto-detection to simplify switching to shared-hosts mode. The problem is that we would need to change both the paths in `site.php` (make `public` equal the `base` path), and the include in `index.php`. (The latter could be done at the expense of another stat call, but for `site.php`, I don't know.)

With this change, users switching to shared-hosts mode would still need to change/write two files. Not sure if that really is an improvement over the status quo.