### PR TITLE
nginx rule to prevent access to sensitive files

### DIFF
--- a/.nginx.conf
+++ b/.nginx.conf
@@ -5,7 +5,7 @@ location / {
 
 # Uncomment the following lines if you are not using a `public` directory
 # to prevent sensitive resources from being exposed.
-# location ~* ^/(composer\.(json|lock)|config\.php|flarum|storage|vendor) {
+# location ~* ^/(\.git|composer\.(json|lock)|auth\.json|config\.php|flarum|storage|vendor) {
 #   deny all;
 #   return 404;
 # }

--- a/.nginx.conf
+++ b/.nginx.conf
@@ -3,6 +3,13 @@ location / {
   try_files $uri $uri/ /index.php?$query_string;
 }
 
+# Uncomment the following lines if you are not using a `public` directory
+# to prevent sensitive resources from being exposed.
+# location ~* ^/(composer\.(json|lock)|config\.php|flarum|storage|vendor) {
+#   deny all;
+#   return 404;
+# }
+
 # The following directives are based on best practices from H5BP Nginx Server Configs
 # https://github.com/h5bp/server-configs-nginx
 


### PR DESCRIPTION
Add a suggested rule that does the same as the suggested rule in .htaccess.

This is the rule I've been using in production on my sites that are not using a public folder.

We should also update the documentation to suggest un-commentating those lines, just like we do for Apache.