### PR TITLE
Add IIS config for easier windows setup

### DIFF
--- a/public/web.config
+++ b/public/web.config
@@ -9,14 +9,12 @@
         </defaultDocument>
         <rewrite>
             <rules>
-                <!-- Uncomment the rule below if you are not using the `public` directory to
+                <!-- Changed `enabled=` to true in the rule below if you are not using the `public` directory to
                 prevent sensitve resources from being exposed -->
-                <!--
-                <rule name="Disallow sensitive directories" stopProcessing="true">
+                <rule name="Disallow sensitive directories" enabled="false" stopProcessing="true">
                     <match url="^/(\.git|composer\.(json|lock)|auth\.json|config\.php|flarum|storage|vendor)" ignoreCase="false" />
                     <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
                 </rule>
-                -->
                 <rule name="Handle index.php re-write" stopProcessing="true">
                     <match url="^" ignoreCase="false" />
                     <conditions logicalGrouping="MatchAll">

--- a/public/web.config
+++ b/public/web.config
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+        <defaultDocument>
+            <files>
+                <clear />
+                <add value="Index.php" />
+            </files>
+        </defaultDocument>
+        <rewrite>
+            <rules>
+                <rule name="Disallow .git" stopProcessing="true">
+                    <match url="/\.git" ignoreCase="false" />
+                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
+                </rule>
+                <rule name="Disallow auth.json" stopProcessing="true">
+                    <match url="^auth\.json$" ignoreCase="false" />
+                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
+                </rule>
+                <rule name="Disallow composer.lock and json" stopProcessing="true">
+                    <match url="^composer\.(lock|json)$" ignoreCase="false" />
+                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
+                </rule>
+                <rule name="Disallow config.php" stopProcessing="true">
+                    <match url="^config.php$" ignoreCase="false" />
+                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
+                </rule>
+                <rule name="Imported Rule" stopProcessing="true">
+                    <match url="^flarum$" ignoreCase="false" />
+                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
+                </rule>
+                <rule name="Disallow storage directory" stopProcessing="true">
+                    <match url="^storage/(.*)?$" ignoreCase="false" />
+                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
+                </rule>
+                <rule name="Disallow vendor directory" stopProcessing="true">
+                    <match url="^vendor/(.*)?$" ignoreCase="false" />
+                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
+                </rule>
+                <rule name="Handle index.php re-write" stopProcessing="true">
+                    <match url="^" ignoreCase="false" />
+                    <conditions logicalGrouping="MatchAll">
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
+                        <add input="{REQUEST_FILENAME}" matchType="IsDirectory" ignoreCase="false" negate="true" />
+                    </conditions>
+                    <action type="Rewrite" url="index.php" appendQueryString="true" />
+                </rule>
+            </rules>
+        </rewrite>
+  </system.webServer>
+</configuration>

--- a/public/web.config
+++ b/public/web.config
@@ -9,34 +9,14 @@
         </defaultDocument>
         <rewrite>
             <rules>
-                <rule name="Disallow .git" stopProcessing="true">
-                    <match url="/\.git" ignoreCase="false" />
+                <!-- Uncomment the rule below if you are not using the `public` directory to
+                prevent sensitve resources from being exposed -->
+                <!--
+                <rule name="Disallow sensitive directories" stopProcessing="true">
+                    <match url="^/(\.git|composer\.(json|lock)|auth\.json|config\.php|flarum|storage|vendor)" ignoreCase="false" />
                     <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
                 </rule>
-                <rule name="Disallow auth.json" stopProcessing="true">
-                    <match url="^auth\.json$" ignoreCase="false" />
-                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
-                </rule>
-                <rule name="Disallow composer.lock and json" stopProcessing="true">
-                    <match url="^composer\.(lock|json)$" ignoreCase="false" />
-                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
-                </rule>
-                <rule name="Disallow config.php" stopProcessing="true">
-                    <match url="^config.php$" ignoreCase="false" />
-                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
-                </rule>
-                <rule name="Imported Rule" stopProcessing="true">
-                    <match url="^flarum$" ignoreCase="false" />
-                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
-                </rule>
-                <rule name="Disallow storage directory" stopProcessing="true">
-                    <match url="^storage/(.*)?$" ignoreCase="false" />
-                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
-                </rule>
-                <rule name="Disallow vendor directory" stopProcessing="true">
-                    <match url="^vendor/(.*)?$" ignoreCase="false" />
-                    <action type="CustomResponse" url="/" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
-                </rule>
+                -->
                 <rule name="Handle index.php re-write" stopProcessing="true">
                     <match url="^" ignoreCase="false" />
                     <conditions logicalGrouping="MatchAll">


### PR DESCRIPTION
Add a `web.config` file to the public directory would do the same thing for IIS that .htaccess does for Apache in regards to automatically setting up the rewrite rules. I believe that this would drastically reduce the number of users having a hard time with IIS.

(HUGE thanks to https://discuss.flarum.org/d/24573-newbie-installation-guide-windows-w-plesk for the initial work on this, all credit goes to AntVincent, @katosdev and phenomlabs on the forums)