### PR TITLE
Add text/javascript to gzip_types in .nginx.conf

### DIFF
--- a/.nginx.conf
+++ b/.nginx.conf
@@ -62,6 +62,7 @@ gzip_types
     image/x-icon
     text/cache-manifest
     text/css
+    text/javascript
     text/plain
     text/vcard
     text/vnd.rim.location.xloc


### PR DESCRIPTION
A quick fix to the issue mentioned in https://discuss.flarum.org/d/29290-gzip-rules-in-the-default-nginxconf

Add text/javascript to gzip_types in .nginx.conf allows to gzip the *.js files when using the nginx server. 

**How to test**
curl -H "Accept-Encoding: gzip" -I https://*flarum-nginx-website*/assets/forum.js

Without "text/javascript" it returns:
...
accept-ranges: bytes
...

With "text/javascript" it returns:
...
content-encoding: gzip
...