### PR TITLE
kom/update-readme-file Fix wrong readme repo names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 <p align="center"><img src="https://flarum.org/assets/img/logo.png"></p>
 
 <p align="center">
-<a href="https://travis-ci.org/flarum/core"><img src="https://travis-ci.org/flarum/core.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/flarum/core"><img src="https://poser.pugx.org/flarum/core/d/total.svg" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/flarum/core"><img src="https://poser.pugx.org/flarum/core/v/stable.svg" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/flarum/core"><img src="https://poser.pugx.org/flarum/core/license.svg" alt="License"></a>
+<a href="https://packagist.org/packages/flarum/flarum"><img src="https://poser.pugx.org/flarum/flarum/d/total.svg" alt="Total Downloads"></a>
+<a href="https://packagist.org/packages/flarum/flarum"><img src="https://poser.pugx.org/flarum/flarum/v/stable.svg" alt="Latest Stable Version"></a>
+<a href="https://packagist.org/packages/flarum/flarum"><img src="https://poser.pugx.org/flarum/flarum/license.svg" alt="License"></a>
 </p>
 
 ## About Flarum


### PR DESCRIPTION
Fix wrong repository names in readme file and removed travis.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
