### PR TITLE
docs: update copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2021 Stichting Flarum (Flarum Foundation)
+Copyright (c) 2019-2022 Stichting Flarum (Flarum Foundation)
 Copyright (c) 2014-2019 Toby Zerner (toby.zerner@gmail.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Fixes [N/A]

**Changes proposed in this pull request:**
Update copyright year from 2021 to 2022.

**Reviewers should focus on:**
N/A

**Screenshot**
N/A

**Necessity**

- [x] N/A

**Confirmed**

- [x] N/A

**Required changes:**

- [x] N/A
