### PR TITLE
Add one click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Installation
 
-Read the **[Installation guide](https://docs.flarum.org/install)** to get started. Or to [self-host Flarum in one-click](https://app.trydome.io/signup?package=flarum) on the cloud try [Dome](https://trydome.io) For support, refer to the [documentation](https://docs.flarum.org/), and ask questions on the [community forum](https://discuss.flarum.org/) or [Discord chat](https://flarum.org/discord/).
+Read the **[Installation guide](https://docs.flarum.org/install)** to get started. Or to [self-host Flarum in one-click](https://app.trydome.io/signup?package=flarum) on the cloud try [Dome](https://trydome.io). For support, refer to the [documentation](https://docs.flarum.org/), and ask questions on the [community forum](https://discuss.flarum.org/) or [Discord chat](https://flarum.org/discord/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Installation
 
-Read the **[Installation guide](https://docs.flarum.org/install)** to get started. For support, refer to the [documentation](https://docs.flarum.org/), and ask questions on the [community forum](https://discuss.flarum.org/) or [Discord chat](https://flarum.org/discord/).
+Read the **[Installation guide](https://docs.flarum.org/install)** to get started. Or to [self-host Flarum in one-click](https://app.trydome.io/signup?package=flarum) on the cloud try [Dome](https://trydome.io) For support, refer to the [documentation](https://docs.flarum.org/), and ask questions on the [community forum](https://discuss.flarum.org/) or [Discord chat](https://flarum.org/discord/).
 
 ## Contributing
 


### PR DESCRIPTION
Hey!

We build this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:
https://e36cbec77a56676a335f676f26e1933783f6575c.dome.tools

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.
