### PR TITLE
Fix Flarum logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<a href="https://flarum.org/"><img src="https://flarum.org/assets/img/logo.png"></a>
+<a href="https://flarum.org/"><img src="https://discuss.flarum.org/assets/logo-2q2rcevl.png"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<a href="https://flarum.org/"><img src="https://discuss.flarum.org/assets/logo-2q2rcevl.png"></a>
+<a href="https://flarum.org/"><img src="https://flarum.org/images/flarum.svg"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
**Changes proposed in this pull request:**

- Fix Flarum logo in `README.md`

**Screenshot**

Before fix:

<img width="1091" alt="image" src="https://github.com/flarum/flarum/assets/1460709/290c0450-21cc-4604-9f47-ed5b3687f27e">

After fix:

<img width="1099" alt="image" src="https://github.com/flarum/flarum/assets/1460709/64676da9-f09d-41d7-86ad-70e11006686e">


