### PR TITLE
Add webp caching.nginx.conf

### DIFF
--- a/.nginx.conf
+++ b/.nginx.conf
@@ -24,7 +24,7 @@ location ~* \.(?:rss|atom)$ {
   add_header Cache-Control "max-age=3600";
 }
 
-location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|mp4|ogg|ogv|webm|htc)$ {
+location ~* \.(?:jpg|jpeg|gif|png|webp|ico|cur|gz|svg|mp4|ogg|ogv|webm|htc)$ {
   add_header Cache-Control "max-age=2592000";
   access_log off;
 }


### PR DESCRIPTION

**Changes proposed in this pull request:**
With Flarum 2.0 converting avatars and logos to webp I’ve added cache settings to the nginx config to align with other image types

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

Server caching config so does not affect core code

**Required changes:**
